### PR TITLE
Update Dockerfile latest MariaDB/TileDB versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV MTR_MEM /tmp
 
 WORKDIR /tmp
 
-ENV TILEDB_VERSION="1.7.0"
+ENV TILEDB_VERSION="1.7.5"
 
 # Install tiledb using 1.7 release
 RUN mkdir build_deps && cd build_deps \
@@ -63,9 +63,9 @@ RUN mkdir build_deps && cd build_deps \
  && make -C tiledb install \
  && cd /tmp && rm -r build_deps
 
-ENV MARIADB_VERSION="mariadb-10.4.8"
+ENV MARIADB_VERSION="mariadb-10.4.12"
 
-ARG MYTILE_VERSION="0.2.2"
+ARG MYTILE_VERSION="0.4.1"
 
 # Download mytile release
 RUN wget https://github.com/TileDB-Inc/TileDB-MariaDB/archive/${MYTILE_VERSION}.tar.gz -O /tmp/${MYTILE_VERSION}.tar.gz \


### PR DESCRIPTION
MariaDB archives don't always keep all old versions, we were getting false failures to do cdns missing 10.4.8