### PR TITLE
Use atexit to only shutdown MariaDB on module exit

### DIFF
--- a/tiledb/sql/__init__.py
+++ b/tiledb/sql/__init__.py
@@ -37,6 +37,7 @@ from ._mysql import (
     InternalError,
     Warning,
     server_init,
+    server_end,
 )
 from tiledb.sql.constants import FIELD_TYPE
 from tiledb.sql.times import (
@@ -47,6 +48,11 @@ from tiledb.sql.times import (
     TimeFromTicks,
     TimestampFromTicks,
 )
+
+# Shutdown the server only on module exit
+import atexit
+
+atexit.register(server_end)
 
 import os
 

--- a/tiledb/sql/_mysql.c
+++ b/tiledb/sql/_mysql.c
@@ -791,7 +791,6 @@ _mysql_ConnectionObject_close(
     check_connection(self);
     Py_BEGIN_ALLOW_THREADS
     mysql_close(&(self->connection));
-    _mysql_server_end(self, NULL);
     Py_END_ALLOW_THREADS
     self->open = 0;
     _mysql_ConnectionObject_clear(self);
@@ -2140,7 +2139,6 @@ _mysql_ConnectionObject_dealloc(
     if (self->open) {
         mysql_close(&(self->connection));
         self->open = 0;
-        _mysql_server_end(self, NULL);
     }
     Py_CLEAR(self->converter);
     MyFree(self);


### PR DESCRIPTION
The MariaDB embedded server can only be started once per process. You can open as many connections as you want, but the starting of the server can only happen once. Currently the start is protected fine, but on connection close the server was shutdown. This meant that open and closing connections was causing segfaults because MariaDB can't be started again once it is stopped in embedded mode. The change here makes the stopping of the server happen as global process level when the python module is unloaded.