### PR TITLE
Install SQLAlchemy in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN pip3 install -r requirements.txt
 
 RUN pip3 install .
 
-RUN pip3 install pandas numpy tiledb
+RUN pip3 install pandas numpy tiledb sqlalchemy
 
 WORKDIR /opt/
 


### PR DESCRIPTION
I tried using the Docker image [tiledb/tiledb-sql-py](https://hub.docker.com/r/tiledb/tiledb-sql-py) as described in the documentation section [Embedded SQL](https://docs.tiledb.com/main/how-to/embedded-sql#usage-in-python). However, I can't do much without first installing the dependency SQLAlchemy. In this PR I installed it directly in the Dockerfile, since that is also where tiledb is installed, but I must admit I'm a little confused why tiledb and sqlalchemy aren't direct dependencies of the Python package tiledb-sql.

I got the code to print the tiledb-sql version from the tutorial notebook [arrays_dense_basics](https://cloud.tiledb.com/notebooks/details/TileDB-Inc/arrays_dense_basics/preview), which I found in the [tutorials section](https://docs.tiledb.com/main/tutorials/arrays#dense-arrays). I confirmed that all the SQL-related code in that notebook runs in TileDB Cloud, but that environment also has SQLAlchemy pre-installed.

## Without SQLAlchemy

```sh
docker run -it --rm tiledb/tiledb-sql-py:2.1.3
# Alternatively, using the checksum
docker run -it --rm tiledb/tiledb-sql-py@sha256:3801be1b54f33559f12a6f6c2d65532e7d16e525ddebe5fd0d854931a1f98ef8
```

```python
import pandas as pd
import tiledb
import tiledb.sql

print("TileDB core version: {}".format(tiledb.libtiledb.version()))
## TileDB core version: (2, 6, 1)
print("TileDB-Py version: {}".format(tiledb.version()))
## TileDB-Py version: (0, 12, 1)
db = tiledb.sql.connect()
print("TileDB-SQL-Py version: {}".format(pd.read_sql("SELECT PLUGIN_AUTH_VERSION FROM information_schema.PLUGINS WHERE PLUGIN_NAME='mytile'", con=db)['PLUGIN_AUTH_VERSION'][0]))
## Traceback (most recent call last):
##   File "/usr/local/lib/python3.8/dist-packages/pandas/compat/_optional.py", line 126, in import_optional_dependency
##     module = importlib.import_module(name)
##   File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
##     return _bootstrap._gcd_import(name[level:], package, level)
##   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
##   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
##   File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
## ModuleNotFoundError: No module named 'sqlalchemy'
## 
## During handling of the above exception, another exception occurred:
## 
## Traceback (most recent call last):
##   File "<stdin>", line 1, in <module>
##   File "/usr/local/lib/python3.8/dist-packages/pandas/io/sql.py", line 563, in read_sql
##     pandas_sql = pandasSQL_builder(con)
##   File "/usr/local/lib/python3.8/dist-packages/pandas/io/sql.py", line 750, in pandasSQL_builder
##     sqlalchemy = import_optional_dependency("sqlalchemy")
##   File "/usr/local/lib/python3.8/dist-packages/pandas/compat/_optional.py", line 129, in import_optional_dependency
##     raise ImportError(msg)
## ImportError: Missing optional dependency 'SQLAlchemy'.  Use pip or conda to install SQLAlchemy.

tiledb.from_pandas("test", pd.util.testing.makeMissingDataframe())
## /usr/local/lib/python3.8/dist-packages/tiledb/dataframe_.py:36: UserWarning: PyArrow version >= 1.0 is suggested for dataframe functionality.
##                   Please `pip install pyarrow>=1.0`.
##   warnings.warn(pa_error)
## /usr/local/lib/python3.8/dist-packages/tiledb/dataframe_.py:36: UserWarning: PyArrow version >= 1.0 is suggested for dataframe functionality.
##                   Please `pip install pyarrow>=1.0`.
##   warnings.warn(pa_error)

pd.read_sql(sql="select * from test", con=db)
## Traceback (most recent call last):
##   File "/usr/local/lib/python3.8/dist-packages/pandas/compat/_optional.py", line 126, in import_optional_dependency
##     module = importlib.import_module(name)
##   File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
##     return _bootstrap._gcd_import(name[level:], package, level)
##   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
##   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
##   File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
## ModuleNotFoundError: No module named 'sqlalchemy'
## 
## During handling of the above exception, another exception occurred:
## 
## Traceback (most recent call last):
##   File "<stdin>", line 1, in <module>
##   File "/usr/local/lib/python3.8/dist-packages/pandas/io/sql.py", line 563, in read_sql
##     pandas_sql = pandasSQL_builder(con)
##   File "/usr/local/lib/python3.8/dist-packages/pandas/io/sql.py", line 750, in pandasSQL_builder
##     sqlalchemy = import_optional_dependency("sqlalchemy")
##   File "/usr/local/lib/python3.8/dist-packages/pandas/compat/_optional.py", line 129, in import_optional_dependency
##     raise ImportError(msg)
## ImportError: Missing optional dependency 'SQLAlchemy'.  Use pip or conda to install SQLAlchemy.
```

## With SQLAlchemy

```sh
docker run -it --rm tiledb/tiledb-sql-py:2.1.3 bash
pip install sqlalchemy
python3
```

```python
import pandas as pd
import tiledb
import tiledb.sql

db = tiledb.sql.connect()
print("TileDB-SQL-Py version: {}".format(pd.read_sql("SELECT PLUGIN_AUTH_VERSION FROM information_schema.PLUGINS WHERE PLUGIN_NAME='mytile'", con=db)['PLUGIN_AUTH_VERSION'][0]))
## /usr/local/lib/python3.8/dist-packages/pandas/io/sql.py:758: UserWarning: pandas only support SQLAlchemy connectable(engine/connection) ordatabase string URI or sqlite3 DBAPI2 connectionother DBAPI2 objects are not tested, please consider using SQLAlchemy
##   warnings.warn(
## TileDB-SQL-Py version: 0.12.1

tiledb.from_pandas("test", pd.util.testing.makeMissingDataframe())
pd.read_sql(sql="select * from test", con=db).head()
## /usr/local/lib/python3.8/dist-packages/pandas/io/sql.py:758: UserWarning: pandas only support SQLAlchemy connectable(engine/connection) ordatabase string URI or sqlite3 DBAPI2 connectionother DBAPI2 objects are not tested, please consider using SQLAlchemy
##   warnings.warn(
##   __tiledb_rows         B         D         C         A
## 0    0ra5LlyZHS  0.000000  0.000000 -0.154760 -0.726731
## 1    1HjMv40Bzw  0.825381  0.634489  1.402688 -1.349600
## 2    2AlJa5j92q  0.061247  1.410284  2.277921 -1.166845
## 3    3ORBRZSvMA -0.619369  0.283196  0.000000 -0.811916
## 4    63mBvdtuEZ  1.492317  0.289488  0.811735  0.900304
```

