### PR TITLE
Change mysql includes to use ```<>```

### DIFF
--- a/tiledb/sql/_mysql.c
+++ b/tiledb/sql/_mysql.c
@@ -26,16 +26,22 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 */
 
-#ifdef HAVE_MYSQL_MYSQL_H
+#if __has_include(<mysql/mysql.h>)
 #include <mysql/mysql.h>
 #else
 #include "mysql.h"
 #endif
 
-#ifdef HAVE_MYSQL_MYSQLD_ERROR_H
+#if __has_include(<mysql/mysqld_error.h>)
 #include <mysql/mysqld_error.h>
 #else
 #include "mysqld_error.h"
+#endif
+
+#if __has_include(<mysql/errmsg.h>)
+#include <mysql/errmsg.h>
+#else
+#include "errmsg.h"
 #endif
 
 #if MYSQL_VERSION_ID >= 80000
@@ -60,12 +66,6 @@ PERFORMANCE OF THIS SOFTWARE.
 
 #include "bytesobject.h"
 #include "structmember.h"
-
-#ifdef HAVE_MYSQL_ERRMSG_H
-#include <mysql/errmsg.h>
-#else
-#include "errmsg.h"
-#endif
 
 #define MyAlloc(s,t) (s *) t.tp_alloc(&t,0)
 #define MyFree(o) Py_TYPE(o)->tp_free((PyObject*)o)

--- a/tiledb/sql/_mysql.c
+++ b/tiledb/sql/_mysql.c
@@ -26,8 +26,17 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include "mysql.h"
+#ifdef HAVE_MYSQL_MYSQL_H
+#include <mysql/mysql.h>
+#else
+#include <mysql.h>
+#endif
+
+#ifdef HAVE_MYSQL_MYSQLD_ERROR_H
+#include <mysql/mysqld_error.h>
+#else
 #include "mysqld_error.h"
+#endif
 
 #if MYSQL_VERSION_ID >= 80000
 // https://github.com/mysql/mysql-server/commit/eb821c023cedc029ca0b06456dfae365106bee84
@@ -51,7 +60,12 @@ PERFORMANCE OF THIS SOFTWARE.
 
 #include "bytesobject.h"
 #include "structmember.h"
+
+#ifdef HAVE_MYSQL_ERRMSG_H
+#include <mysql/errmsg.h>
+#else
 #include "errmsg.h"
+#endif
 
 #define MyAlloc(s,t) (s *) t.tp_alloc(&t,0)
 #define MyFree(o) Py_TYPE(o)->tp_free((PyObject*)o)

--- a/tiledb/sql/_mysql.c
+++ b/tiledb/sql/_mysql.c
@@ -29,7 +29,7 @@ PERFORMANCE OF THIS SOFTWARE.
 #ifdef HAVE_MYSQL_MYSQL_H
 #include <mysql/mysql.h>
 #else
-#include <mysql.h>
+#include "mysql.h"
 #endif
 
 #ifdef HAVE_MYSQL_MYSQLD_ERROR_H


### PR DESCRIPTION
This fix should be part of a new release that will be used in libtiledb-sql-py to fix the ```missing symbol``` error in macOS-arm64. It has been tested on all platforms.